### PR TITLE
Using homeCity metadata instead of hardcoding 'San Francisco'

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,7 +36,7 @@ class BlogIndexRoute extends React.Component {
             <strong>{this.props.data.site.siteMetadata.author}</strong>
             {" "}
             who lives and works
-            in San Francisco building really useful things. You should
+            in {this.props.data.site.siteMetadata.homeCity} building really useful things. You should
             {" "}
             <a href="https://twitter.com/kylemathews">follow him on Twitter</a>
           </p>
@@ -72,6 +72,7 @@ query IndexQuery {
     siteMetadata {
       title
       author
+      homeCity
     }
   }
   allMarkdownRemark(

--- a/src/pages/template-blog-post.js
+++ b/src/pages/template-blog-post.js
@@ -95,7 +95,7 @@ class BlogPostRoute extends React.Component {
           />
           <strong>{this.props.data.site.siteMetadata.author}</strong>
           {" "}
-          lives and works in San Francisco building useful things.
+          lives and works in {this.props.data.site.siteMetadata.homeCity} building useful things.
           {" "}
           <a href="https://twitter.com/kylemathews">
             You should follow him on Twitter
@@ -113,6 +113,7 @@ query BlogPostBySlug($slug: String!) {
   site {
     siteMetadata {
       author
+      homeCity
     }
   }
   markdownRemark(slug: { eq: $slug }) {


### PR DESCRIPTION
Hi! While looking at your site's code to learn how to use Gatsby v1, I discovered that you didn't use your homecity metadata, so here's a PR to change that :)