### PR TITLE
Ensure RSS feed is linked consistently

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,14 +119,7 @@ module.exports = {
               }
             `,
             output: "/rss.xml",
-            title: "Your Site's RSS Feed",
-            // optional configuration to insert feed reference in pages:
-            // if `string` is used, it will be used to create RegExp and then test if pathname of
-            // current page satisfied this regular expression;
-            // if not provided or `undefined`, all pages will have feed reference inserted
-            match: "^/blog/",
-            // optional configuration to specify external rss feed, such as feedburner
-            link: "https://feeds.feedburner.com/gatsby/blog",
+            title: "Bricolage",
           },
         ],
       },


### PR DESCRIPTION
Hey @KyleAMathews. 👋 

This PR fixes a few things in your RSS feed, to make it more accurate and findable:

- Updates the feed title: `Your Site's RSS Feed` → `Bricolage`
- Removes the example external feed (https://feeds.feedburner.com/gatsby/blog), which doesn't point to your site. I think it was accidentally copied over from [the `gatsby-plugin-feed` docs](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed#additional-options) previously.
- Removes the `match` criteria
  - This is because the `<link type="application/rss+xml" ...>` isn't updated on client-side transitions. As a result, if you enter the site on the home-page, and navigate to /blog, you won't see the `<link>` on the /blog page, which makes the feed less discoverable. I think the easiest solution is to include the `<link>` on all pages by default ([as recommended here](https://blog.jim-nielsen.com/2021/automatically-discoverable-rss-feeds)), and removing the match property does that.